### PR TITLE
minor edit to correct where to find migrations

### DIFF
--- a/content/post/2017-09-22-using-ecto-and-sqlite3-with-nerves.md
+++ b/content/post/2017-09-22-using-ecto-and-sqlite3-with-nerves.md
@@ -166,7 +166,7 @@ defp migrate_repo!(repo) do
 
   migrator = &Ecto.Migrator.run/4
   pool = repo.config[:pool]
-  migrations_path = Path.join((:code.priv_dir(@otp_app) |> to_string), "repo")
+  migrations_path = Path.join([:code.priv_dir(@otp_app) |> to_string, "repo", "migrations"])
   migrated =
     if function_exported?(pool, :unboxed_run, 2) do
       pool.unboxed_run(repo, fn -> migrator.(repo, migrations_path, :up, opts) end)

--- a/content/post/2017-09-22-using-ecto-and-sqlite3-with-nerves.md
+++ b/content/post/2017-09-22-using-ecto-and-sqlite3-with-nerves.md
@@ -147,8 +147,10 @@ end
 defp setup_db! do
   repos = Application.get_env(@otp_app, :ecto_repos)
   for repo <- repos do
-    setup_repo!(repo)
-    migrate_repo!(repo)
+    if Application.get_env(@otp_app, repo)[:adapter] == Elixir.Sqlite.Ecto2 do
+      setup_repo!(repo)
+      migrate_repo!(repo)
+    end
   end
   :ok
 end


### PR DESCRIPTION
Frank, Justin

Thanks for this excellent post. I'd love to share the talk I did in St. Louis with Amos and Bryan, demonstrating how to code an API service embedded on a pi. This information was a fundamental building block.

Ecto puts all the migrations in a folder _under_ the repo dir, so I made a small edit to the path-join to get the schema established.

Less critical, but still very interesting to me, was the conditional check for the configured adapter, to prevent this sqlite-migration code from running under postgres or mysql etc.